### PR TITLE
fix: make pre-commit install deptry

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
     name: deptry
     description: deptry is a command line tool to check for issues with dependencies in a Python project, such as unused or missing dependencies.
     entry: deptry .
-    language: system
+    language: python
     always_run: true
     pass_filenames: false


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

Fixes #414 

This PR changes pre-commit language to `python`, so pre-commit calls `pip install .` before running `deptry` during hook execution. This way the version from the cloned repository is used instead and it doesn't depend on system-wide/project-wide installation.

This behavior is expected by `pre-commit` users.