### PR TITLE
test(functional): enforce utf-8 encoding when building wheel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Run functional tests
         run: uv run pytest tests/functional -n auto --dist loadgroup
+        env:
+          PYTHONIOENCODING: 'utf-8'
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,8 +28,8 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         result = subprocess.run(
             shlex.split(f"uv build --verbose --wheel --out-dir {deptry_wheel_path}", posix=sys.platform != "win32"),
             capture_output=True,
-            text=True,
             check=True,
+            encoding="utf-8",
         )
         print(f"uv build output: {result.stdout}")  # noqa: T201
         print(f"uv build errors: {result.stderr}")  # noqa: T201


### PR DESCRIPTION
This avoids the following warning in the CI for Windows, that starting on `pytest` 8.4+ now raises an error:

```python
Traceback (most recent call last):
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\threading.py", line 980, in _bootstrap_inner
    self.run()
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\subprocess.py", line 1479, in _readerthread
    buffer.append(fh.read())
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 3757: character maps to <undefined>
```