### PR TITLE
ci: default to Python 3.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  PYTHON_VERSION: '3.13'
+  PYTHON_VERSION: '3.14'
   # renovate: datasource=pypi depName=uv
   UV_VERSION: '0.8.24'
 
@@ -75,7 +75,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-          - '3.14-dev'
+          - '3.14'
           - 'pypy3.11'
       fail-fast: false
     runs-on: ${{ matrix.os.image }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: '3.13'
+  PYTHON_VERSION: '3.14'
   # renovate: datasource=pypi depName=uv
   UV_VERSION: '0.8.24'
 
@@ -40,7 +40,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
         manylinux: [auto, musllinux_1_1]
-        python: ['3.13', 'pypy3.11']
+        python: ['3.14', 'pypy3.11']
     steps:
       - name: Check out
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -77,10 +77,10 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python: ['3.13', 'pypy3.11']
+        python: ['3.14', 'pypy3.11']
         # PyPy doesn't support Windows ARM64.
         include:
-          - python: '3.13'
+          - python: '3.14'
             target: aarch64
     steps:
       - name: Check out
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.13', 'pypy3.11']
+        python: ['3.14', 'pypy3.11']
     steps:
       - name: Check out
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Default to Python 3.14 on the CI instead of 3.13, as it's now the latest minor.