### PR TITLE
chore: bump rust to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deptryrs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.89"
+rust-version = "1.91"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89"
+channel = "1.91"


### PR DESCRIPTION
Changelogs:
- 1.90: https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/
- 1.91: https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/