### PR TITLE
chore(pyo3): target `abi3-py310`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ encoding_rs = "=0.8.35"
 ignore = "=0.4.25"
 log = "=0.4.28"
 path-slash = "=0.2.1"
-pyo3 = { version = "=0.27.1", features = ["abi3-py39", "generate-import-lib"] }
+pyo3 = { version = "=0.27.1", features = ["abi3-py310", "generate-import-lib"] }
 pyo3-log = "=0.13.2"
 rayon = "=1.11.0"
 regex = "=1.12.2"


### PR DESCRIPTION
Not too problematic, but I forgot to update ABI target to 3.10 in #1328.