### PR TITLE
docs: update description to match `pyproject.toml`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ edit_uri: edit/main/docs/
 repo_name: fpgmaas/deptry
 repo_url: https://github.com/fpgmaas/deptry
 site_url: https://deptry.com
-site_description: A command line tool to check for unused dependencies in a poetry managed python project.
+site_description: A command line utility to check for unused, missing and transitive dependencies in a Python project.
 site_author: Florian Maas
 copyright: Maintained by <a href="https://fpgmaas.com">Florian</a>.
 


### PR DESCRIPTION
Closes #1438.

Update documentation description to match [what we have in `pyproject.toml`](https://github.com/fpgmaas/deptry/blob/e8bd91ddc2c4fa7e1a58e9d432335180e63167e4/pyproject.toml#L4).