### PR TITLE
ci: use `macos-26`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           - name: linux
             image: ubuntu-24.04
           - name: macos
-            image: macos-15
+            image: macos-26
           - name: windows
             image: windows-2025
         python-version:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [set-version]
     strategy:
       matrix:


### PR DESCRIPTION
macOS 26 is now generally available: https://github.com/actions/runner-images/issues/13739.