### PR TITLE
ci: remove unneeded references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  PYTHON_VERSION: '3.14'
-  # renovate: datasource=pypi depName=uv
-  UV_VERSION: '0.10.7'
-
 permissions: {}
 
 jobs:
@@ -29,14 +24,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
-          version: ${{ env.UV_VERSION }}
+          version: '0.10.7'
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
 
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '3.14'
 
       - name: Install Python dependencies
         # We want to install all groups here to make sure that deptry has access to all dependencies for the inspection,
@@ -83,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
-          version: ${{ env.UV_VERSION }}
+          version: '0.10.7'
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
           cache-suffix: ${{ matrix.python-version }}
@@ -112,7 +107,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.os.name == 'linux' && matrix.python-version == env.PYTHON_VERSION }}
+        if: ${{ matrix.os.name == 'linux' && matrix.python-version == '3.14' }}
 
   check-docs:
     runs-on: ubuntu-24.04
@@ -125,13 +120,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
-          version: ${{ env.UV_VERSION }}
+          version: '0.10.7'
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
 
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '3.14'
       - name: Check if documentation can be built
         run: uv run --only-group docs mkdocs build --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  PYTHON_VERSION: '3.14'
-  # renovate: datasource=pypi depName=uv
-  UV_VERSION: '0.10.7'
-
 permissions: {}
 
 jobs:
@@ -162,7 +157,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '3.14'
 
       - name: Download updated pyproject.toml
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -195,7 +190,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '3.14'
 
       - name: Publish to PyPI
         if: ${{ github.event_name == 'release' }}
@@ -219,20 +214,20 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out
+      - name: Check out  # zizmor: ignore[artipacked] -- required for publishing documentation to `gh-pages` branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
-          version: ${{ env.UV_VERSION }}
+          version: '0.10.7'
           enable-cache: true
           cache-dependency-glob: 'uv.lock'
 
       - name: Install Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '3.14'
 
       - name: Deploy documentation
         if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -8,12 +8,6 @@ on:
   push:
     branches: [main]
 
-env:
-  # renovate: datasource=node depName=node versioning=node
-  NODE_VERSION: '24'
-  # renovate: datasource=npm depName=pnpm
-  PNPM_VERSION: '10.30.3'
-
 permissions: {}
 
 jobs:
@@ -25,10 +19,10 @@ jobs:
           persist-credentials: false
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: ${{ env.PNPM_VERSION }}
+          version: '10.30.3'
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: '24'
       # Avoid installing packages that are newer than 1 week old to reduce supply chain attacks probability.
       - run: pnpm config set minimumReleaseAge 10080
       - run: pnpm --package renovate dlx renovate-config-validator

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,5 +1,0 @@
-rules:
-  artipacked:
-    ignore:
-      # Required for publishing documentation to `gh-pages` branch.
-      - release.yml:222


### PR DESCRIPTION
Per https://docs.renovatebot.com/modules/manager/github-actions/#withversion-support-for-built-in-actions, Renovate is already able to get the references behind several actions.