### PR TITLE
chore(renovate): fix uv grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,7 +85,8 @@
       allowedVersions: "<4",
     },
     {
-      matchPackageNames: ["uv", "astral-sh/uv-pre-commit"],
+      matchDatasources: ["github-releases", "github-tags"],
+      matchPackageNames: ["astral-sh/uv", "astral-sh/uv-pre-commit"],
       groupName: "uv-version",
     },
   ],


### PR DESCRIPTION
Following https://github.com/fpgmaas/deptry/pull/1486, uv is now detected as a `astral-sh/uv` from `github-releases`.