### PR TITLE
feat: add VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ deptry.json
 .DS_Store
 .vscode
 
+# VS Code extension build artifacts
+vscode-extension/out/
+vscode-extension/node_modules/
+vscode-extension/*.vsix
+
 # From https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 
  Byte-compiled / optimized / DLL files

--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,7 @@
+.vscode/**
+node_modules/**
+src/**
+tsconfig.json
+**/*.map
+**/*.ts
+!out/**

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,67 @@
+# deptry — VS Code Extension
+
+Surfaces [deptry](https://deptry.com) dependency violations as inline diagnostics in VS Code.
+
+## Features
+
+- Runs `deptry` automatically on save and shows issues in the Problems panel
+- Inline squiggles on the offending import or dependency definition
+- Each diagnostic links to the relevant rule documentation
+- Status bar item showing live run state and issue count
+
+### Detected issues
+
+| Code | Description |
+|------|-------------|
+| DEP001 | Import missing from dependency definitions |
+| DEP002 | Dependency declared but not used |
+| DEP003 | Transitive dependency used directly |
+| DEP004 | Dev dependency used in non-dev code |
+| DEP005 | Standard library module declared as dependency |
+
+## Requirements
+
+`deptry` must be installed in your project's virtual environment:
+
+```bash
+pip install deptry
+# or
+uv add --dev deptry
+```
+
+The extension automatically discovers the deptry binary from:
+1. The Python interpreter selected in the VS Code Python extension
+2. Common local venv directories (`.venv`, `venv`, `env`)
+3. `deptry` on your system `PATH`
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `deptry.executable` | `"deptry"` | Explicit path to binary (e.g. `.venv/bin/deptry`) |
+| `deptry.runOnSave` | `true` | Re-run on Python / `pyproject.toml` save |
+| `deptry.args` | `[]` | Extra CLI arguments (e.g. `["--ignore", "DEP002"]`) |
+| `deptry.rootDirectory` | `""` | Directory to scan. Defaults to workspace root so that deptry uses your `pyproject.toml` config |
+| `deptry.severityMap` | see below | Map error codes to diagnostic severity |
+
+Default severity map:
+```json
+{
+  "DEP001": "error",
+  "DEP002": "warning",
+  "DEP003": "warning",
+  "DEP004": "error",
+  "DEP005": "warning"
+}
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `deptry: Run Dependency Check` | Run deptry manually |
+| `deptry: Clear Diagnostics` | Clear all deptry diagnostics |
+
+## How it works
+
+The extension runs `deptry . --json-output <tmpfile>` from your workspace root, parses the JSON output, and maps each violation to a VS Code diagnostic on the relevant file and line.

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "deptry",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deptry",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.3.0"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
+      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "deptry",
+  "displayName": "deptry",
+  "description": "Python dependency checker — surface deptry violations as VS Code diagnostics",
+  "version": "0.2.0",
+  "publisher": "RamuKamath",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fpgmaas/deptry"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Linters"],
+  "keywords": ["python", "dependencies", "linter", "deptry"],
+  "activationEvents": [
+    "onLanguage:python",
+    "workspaceContains:pyproject.toml",
+    "workspaceContains:requirements.txt"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "deptry.run",
+        "title": "deptry: Run Dependency Check"
+      },
+      {
+        "command": "deptry.clearDiagnostics",
+        "title": "deptry: Clear Diagnostics"
+      }
+    ],
+    "configuration": {
+      "title": "deptry",
+      "properties": {
+        "deptry.executable": {
+          "type": "string",
+          "default": "deptry",
+          "description": "Path to the deptry executable. Use an absolute path to point at a virtualenv installation (e.g. .venv/bin/deptry)."
+        },
+        "deptry.runOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run deptry automatically whenever a Python file is saved."
+        },
+        "deptry.args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Extra CLI arguments passed to deptry (e.g. [\"--ignore\", \"DEP002\"])."
+        },
+        "deptry.rootDirectory": {
+          "type": "string",
+          "default": "",
+          "description": "Directory passed to deptry as the root to scan. Defaults to the workspace root."
+        },
+        "deptry.severityMap": {
+          "type": "object",
+          "default": {
+            "DEP001": "error",
+            "DEP002": "warning",
+            "DEP003": "warning",
+            "DEP004": "error",
+            "DEP005": "warning"
+          },
+          "description": "Map deptry error codes to VS Code diagnostic severities (\"error\", \"warning\", \"information\", \"hint\").",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["error", "warning", "information", "hint"]
+          }
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,378 @@
+import * as vscode from "vscode";
+import * as cp from "child_process";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DeptryViolation {
+  error: {
+    code: string;
+    message: string;
+  };
+  module: string;
+  location: {
+    file: string;
+    line: number | null;
+    column: number | null;
+  };
+}
+
+type SeverityLabel = "error" | "warning" | "information" | "hint";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DIAGNOSTIC_SOURCE = "deptry";
+const RULE_URLS: Record<string, string> = {
+  DEP001:
+    "https://deptry.com/rules-violations/#dep001-imported-but-missing-from-the-dependency-definitions",
+  DEP002:
+    "https://deptry.com/rules-violations/#dep002-defined-as-a-dependency-but-not-used-in-the-codebase",
+  DEP003:
+    "https://deptry.com/rules-violations/#dep003-imported-but-it-is-a-transitive-dependency",
+  DEP004:
+    "https://deptry.com/rules-violations/#dep004-imported-but-declared-as-a-dev-dependency",
+  DEP005:
+    "https://deptry.com/rules-violations/#dep005-defined-as-a-dependency-but-it-is-a-standard-library-module",
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getSeverity(code: string): vscode.DiagnosticSeverity {
+  const cfg = vscode.workspace
+    .getConfiguration("deptry")
+    .get<Record<string, SeverityLabel>>("severityMap", {});
+  const label: SeverityLabel = cfg[code] ?? "error";
+  switch (label) {
+    case "warning":
+      return vscode.DiagnosticSeverity.Warning;
+    case "information":
+      return vscode.DiagnosticSeverity.Information;
+    case "hint":
+      return vscode.DiagnosticSeverity.Hint;
+    default:
+      return vscode.DiagnosticSeverity.Error;
+  }
+}
+
+function getWorkspaceRoot(): string | undefined {
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+}
+
+/**
+ * Resolve the deptry executable, in priority order:
+ *  1. Explicit `deptry.executable` setting (non-default).
+ *  2. bin/ of the Python interpreter VS Code has selected (Python extension API).
+ *  3. Common local venv directories (.venv, venv, env).
+ *  4. Plain "deptry" on PATH.
+ */
+async function resolveExecutable(workspaceRoot: string): Promise<string> {
+  const config = vscode.workspace.getConfiguration("deptry");
+  const configured: string = config.get("executable", "deptry");
+
+  if (configured !== "deptry") {
+    return configured;
+  }
+
+  // Python extension API
+  const pythonInterpreter = await getActivePythonInterpreter(workspaceRoot);
+  if (pythonInterpreter) {
+    const candidate = path.join(path.dirname(pythonInterpreter), "deptry");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Common local venv directories
+  const binSubdir = process.platform === "win32" ? "Scripts" : "bin";
+  for (const venvDir of [".venv", "venv", "env", ".env"]) {
+    const candidate = path.join(workspaceRoot, venvDir, binSubdir, "deptry");
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return "deptry";
+}
+
+/**
+ * Resolve the directory argument passed to deptry.
+ *
+ * Defaults to "." so that deptry runs from the workspace root and picks up
+ * the project's own pyproject.toml config (including [tool.deptry] excludes,
+ * per_rule_ignores, etc.). This avoids false positives from scanning test
+ * directories that are excluded in the project's deptry config.
+ *
+ * Set `deptry.rootDirectory` to override (e.g. "src" or "python").
+ */
+function resolveRootDirectory(workspaceRoot: string): string {
+  const config = vscode.workspace.getConfiguration("deptry");
+  const configured: string = config.get("rootDirectory", "");
+  if (configured) {
+    return path.isAbsolute(configured)
+      ? configured
+      : path.join(workspaceRoot, configured);
+  }
+  return ".";
+}
+
+async function getActivePythonInterpreter(
+  workspaceRoot: string
+): Promise<string | undefined> {
+  // Prefer the Python extension API (ms-python.python).
+  const pythonExt = vscode.extensions.getExtension("ms-python.python");
+  if (pythonExt) {
+    if (!pythonExt.isActive) {
+      await pythonExt.activate();
+    }
+    // The Python extension API exposes getActiveEnvironmentPath() since 2022.
+    const api = pythonExt.exports as
+      | {
+          environments?: {
+            getActiveEnvironmentPath: (resource?: vscode.Uri) => {
+              path: string;
+            };
+          };
+        }
+      | undefined;
+    const envPath = api?.environments?.getActiveEnvironmentPath(
+      vscode.Uri.file(workspaceRoot)
+    )?.path;
+    if (envPath) {
+      return envPath;
+    }
+  }
+
+  // Fallback: read from VS Code Python settings.
+  const pythonConfig = vscode.workspace.getConfiguration(
+    "python",
+    vscode.Uri.file(workspaceRoot)
+  );
+  return (
+    pythonConfig.get<string>("defaultInterpreterPath") ||
+    pythonConfig.get<string>("pythonPath")
+  );
+}
+
+function buildDiagnostic(
+  violation: DeptryViolation,
+  workspaceRoot: string
+): { uri: vscode.Uri; diagnostic: vscode.Diagnostic } | null {
+  const { file, line, column } = violation.location;
+  const absolutePath = path.isAbsolute(file)
+    ? file
+    : path.join(workspaceRoot, file);
+  const uri = vscode.Uri.file(absolutePath);
+
+  // For violations with no line (e.g. DEP002 pointing at pyproject.toml),
+  // pin the diagnostic to line 0, column 0.
+  const startLine = line != null ? line - 1 : 0;
+  const startChar = column != null ? column : 0;
+  const range = new vscode.Range(startLine, startChar, startLine, startChar + 1);
+
+  const diagnostic = new vscode.Diagnostic(
+    range,
+    violation.error.message,
+    getSeverity(violation.error.code)
+  );
+  diagnostic.source = DIAGNOSTIC_SOURCE;
+  diagnostic.code = {
+    value: violation.error.code,
+    target: vscode.Uri.parse(
+      RULE_URLS[violation.error.code] ?? "https://deptry.com/rules-violations/"
+    ),
+  };
+
+  return { uri, diagnostic };
+}
+
+// ─── Runner ───────────────────────────────────────────────────────────────────
+
+async function runDeptry(
+  diagnosticCollection: vscode.DiagnosticCollection,
+  statusBarItem: vscode.StatusBarItem,
+  outputChannel: vscode.OutputChannel
+): Promise<void> {
+  const workspaceRoot = getWorkspaceRoot();
+  if (!workspaceRoot) {
+    return;
+  }
+
+  const config = vscode.workspace.getConfiguration("deptry");
+  const executable = await resolveExecutable(workspaceRoot);
+  const extraArgs: string[] = config.get("args", []);
+  const runRoot = resolveRootDirectory(workspaceRoot);
+
+  // Write JSON output to a temp file so we can parse it reliably.
+  const tmpFile = path.join(
+    os.tmpdir(),
+    `deptry-${Date.now()}-${Math.random().toString(36).slice(2)}.json`
+  );
+
+  const args = [runRoot, "--json-output", tmpFile, ...extraArgs];
+
+  statusBarItem.text = "$(sync~spin) deptry";
+  statusBarItem.tooltip = "deptry is running…";
+  statusBarItem.show();
+
+  outputChannel.appendLine(`[deptry] Running: ${executable} ${args.join(" ")}`);
+
+  return new Promise((resolve) => {
+    const proc = cp.spawn(executable, args, {
+      cwd: workspaceRoot,
+      env: process.env,
+    });
+
+    let stderr = "";
+    proc.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    proc.stdout.on("data", (chunk: Buffer) => {
+      outputChannel.append(chunk.toString());
+    });
+
+    proc.on("error", (err) => {
+      statusBarItem.text = "$(error) deptry";
+      statusBarItem.tooltip = `deptry failed to start: ${err.message}`;
+      outputChannel.appendLine(`[deptry] Error: ${err.message}`);
+      if (err.message.includes("ENOENT")) {
+        vscode.window.showErrorMessage(
+          `deptry: executable '${executable}' not found. ` +
+            "Set deptry.executable in settings to point at your virtualenv's deptry binary."
+        );
+      }
+      cleanup();
+      resolve();
+    });
+
+    proc.on("close", (code) => {
+      if (stderr) {
+        outputChannel.appendLine(`[deptry] stderr: ${stderr}`);
+      }
+      outputChannel.appendLine(`[deptry] Exit code: ${code}`);
+
+      // Exit code 0 → no issues, 1 → violations found. Both are normal.
+      if (code !== 0 && code !== 1) {
+        statusBarItem.text = "$(warning) deptry";
+        statusBarItem.tooltip = `deptry exited with code ${code}. See Output panel.`;
+        cleanup();
+        resolve();
+        return;
+      }
+
+      let violations: DeptryViolation[] = [];
+      try {
+        if (fs.existsSync(tmpFile)) {
+          const raw = fs.readFileSync(tmpFile, "utf8");
+          violations = JSON.parse(raw) as DeptryViolation[];
+        }
+      } catch (e) {
+        outputChannel.appendLine(`[deptry] Failed to parse JSON output: ${e}`);
+      }
+
+      // Group diagnostics by file URI.
+      const diagMap = new Map<string, vscode.Diagnostic[]>();
+      for (const violation of violations) {
+        const result = buildDiagnostic(violation, workspaceRoot);
+        if (!result) continue;
+        const key = result.uri.toString();
+        if (!diagMap.has(key)) {
+          diagMap.set(key, []);
+        }
+        diagMap.get(key)!.push(result.diagnostic);
+      }
+
+      diagnosticCollection.clear();
+      for (const [uriStr, diags] of diagMap) {
+        diagnosticCollection.set(vscode.Uri.parse(uriStr), diags);
+      }
+
+      const count = violations.length;
+      if (count === 0) {
+        statusBarItem.text = "$(check) deptry";
+        statusBarItem.tooltip = "deptry: no dependency issues found";
+      } else {
+        statusBarItem.text = `$(warning) deptry: ${count} issue${count === 1 ? "" : "s"}`;
+        statusBarItem.tooltip = `deptry found ${count} dependency issue${count === 1 ? "" : "s"}. Click to open Problems panel.`;
+        statusBarItem.command = "workbench.actions.view.problems";
+      }
+
+      cleanup();
+      resolve();
+    });
+
+    function cleanup() {
+      try {
+        if (fs.existsSync(tmpFile)) {
+          fs.unlinkSync(tmpFile);
+        }
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+}
+
+// ─── Activation ───────────────────────────────────────────────────────────────
+
+export function activate(context: vscode.ExtensionContext): void {
+  const diagnosticCollection =
+    vscode.languages.createDiagnosticCollection(DIAGNOSTIC_SOURCE);
+  context.subscriptions.push(diagnosticCollection);
+
+  const outputChannel = vscode.window.createOutputChannel("deptry");
+  context.subscriptions.push(outputChannel);
+
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    100
+  );
+  statusBarItem.name = "deptry";
+  context.subscriptions.push(statusBarItem);
+
+  // Debounce — avoid hammering deptry on rapid saves.
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  function scheduleRun(delay = 500) {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      runDeptry(diagnosticCollection, statusBarItem, outputChannel);
+    }, delay);
+  }
+
+  // Command: run manually.
+  context.subscriptions.push(
+    vscode.commands.registerCommand("deptry.run", () => {
+      scheduleRun(0);
+    })
+  );
+
+  // Command: clear diagnostics.
+  context.subscriptions.push(
+    vscode.commands.registerCommand("deptry.clearDiagnostics", () => {
+      diagnosticCollection.clear();
+      statusBarItem.hide();
+    })
+  );
+
+  // Auto-run on Python file or pyproject.toml save.
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((doc) => {
+      const runOnSave = vscode.workspace
+        .getConfiguration("deptry")
+        .get<boolean>("runOnSave", true);
+      if (!runOnSave) return;
+      if (doc.languageId === "python" || doc.fileName.endsWith(".toml")) {
+        scheduleRun();
+      }
+    })
+  );
+
+  // Run once on activation.
+  scheduleRun(1000);
+}
+
+export function deactivate(): void {
+  // Subscriptions are disposed automatically.
+}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "out",
+    "rootDir": "src",
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Adds a VS Code extension (`vscode-extension/`) that runs `deptry` and surfaces dependency violations as inline diagnostics in the editor.

### Features

- **Auto-discovers** the deptry binary from the VS Code Python extension API, common local venv directories (`.venv`, `venv`, `env`), or `PATH` — works out of the box with no configuration needed
- **Inline diagnostics** for DEP001–DEP005 in the Problems panel, with each diagnostic linking to the relevant rule documentation
- **Runs automatically** on Python / `pyproject.toml` save (debounced 500ms)
- **Status bar item** showing live run state and issue count
- **Configurable** severity per rule, extra CLI args, and root directory override

### How it works

Runs `deptry . --json-output <tmpfile>` from the workspace root (so the project's own `pyproject.toml` config is respected), parses the JSON output, and maps each violation to a VS Code diagnostic.

### Files added

```
vscode-extension/
├── package.json       # extension manifest + settings schema
├── tsconfig.json
├── .vscodeignore
├── README.md
└── src/
    └── extension.ts   # all extension logic (~300 lines)
```

made release to test it. you can find it in marketplace. we might need to remove this and publish under deputy account. or do you have different ideas?

<img width="557" height="147" alt="image" src="https://github.com/user-attachments/assets/778ce5ce-3aac-49a2-bd98-d6b699626924" />

error/warning in panel
<img width="820" height="365" alt="image" src="https://github.com/user-attachments/assets/b89a52a2-3491-42c2-9a6f-56458858652b" />

inline errors
<img width="805" height="119" alt="image" src="https://github.com/user-attachments/assets/ca20bd06-ad6a-43ed-8d1c-bb4ab4127940" />


