### PR TITLE
chore: bump rust to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deptryrs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -177,10 +177,8 @@ fn is_guarded_by_type_checking(if_stmt: &StmtIf, typing_aliases: &HashSet<String
                 return true;
             }
         }
-        Expr::Name(ExprName { id, .. }) => {
-            if id == "TYPE_CHECKING" {
-                return true;
-            }
+        Expr::Name(ExprName { id, .. }) if id == "TYPE_CHECKING" => {
+            return true;
         }
         _ => (),
     }


### PR DESCRIPTION
Changelog: https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/