### PR TITLE
fix(cli): trim whitespace in delimited options

### DIFF
--- a/python/deptry/cli.py
+++ b/python/deptry/cli.py
@@ -45,7 +45,7 @@ class CommaSeparatedTupleParamType(click.ParamType):
         ctx: click.Context | None,
     ) -> tuple[str, ...]:
         if isinstance(value, str):
-            return tuple(value.split(","))
+            return tuple(item.strip() for item in value.split(","))
         if isinstance(value, list):
             return tuple(value)
         return value
@@ -77,14 +77,14 @@ class CommaSeparatedMappingParamType(click.ParamType):
         if isinstance(value, str):
             map_: defaultdict[str, list[str]] = defaultdict(list)
             for item in value.split(","):
-                pair = tuple(item.split("=", 1))
+                pair = tuple(part.strip() for part in item.split("=", 1))
                 if len(pair) != 2:
                     error_msg = (
                         f"package name and module names pairs should be concatenated with an equal sign (=): {item}"
                     )
                     raise ValueError(error_msg)
                 package_name = pair[0]
-                module_names = pair[1].split("|")
+                module_names = (module_name.strip() for module_name in pair[1].split("|"))
                 map_[package_name].extend(module_names)
             converted = {k: tuple(v) for k, v in map_.items()}
         else:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -42,6 +42,11 @@ if TYPE_CHECKING:
             id="from multiple str",
         ),
         pytest.param(
+            "foo, bar ",
+            ("foo", "bar"),
+            id="strips whitespace from multiple str",
+        ),
+        pytest.param(
             [],
             (),
             id="from empty list",
@@ -103,6 +108,11 @@ def test_comma_separated_tuple_param_type_convert(
             "foo=bar,fox=fuz",
             {"foo": ("bar",), "fox": ("fuz",)},
             id="from str, multi key, single value",
+        ),
+        pytest.param(
+            "foo=bar | baz, fox = fuz",
+            {"foo": ("bar", "baz"), "fox": ("fuz",)},
+            id="strips whitespace from keys and values",
         ),
         pytest.param(
             "foo=bar,foo=fuz",


### PR DESCRIPTION
## Summary

- Trim whitespace from comma-separated CLI values.
- Trim mapping keys and values for `--per-rule-ignores`.
- Trim pipe-separated module names in mapping values.
- Add regression tests for whitespace around delimiters.

## Problem

The CLI parser currently preserves whitespace around delimited values. For example, `--ignore DEP001, DEP002` parses the second code as `" DEP002"`, so it does not match the actual violation code.

The same issue affects mapping options such as `--per-rule-ignores DEP001=foo | bar, DEP002=baz`.

## Changes

- Strip each comma-separated tuple item.
- Strip mapping keys and the text around `=`.
- Strip each module name around `|`.
- Preserve existing behavior for values without whitespace.

## Testing

- `python -m py_compile python/deptry/cli.py tests/unit/test_cli.py`
- `uv run --no-default-groups --group test pytest tests/unit/test_cli.py -q`

The targeted pytest command should be run in CI. The current environment stopped during the first Rust toolchain initialization required to build deptry.
