### PR TITLE
chore: bump rust to 1.97

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deptryrs"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.97"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95"
+channel = "1.97"


### PR DESCRIPTION
Changelogs:
- 1.96: https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/
- 1.97: https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/