### PR TITLE
ci: test against Python 3.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
           - '3.13'
           - '3.14'
           - '3.14t'
+          - '3.15-dev'
+          - '3.15t-dev'
           - 'pypy3.11'
       fail-fast: false
     runs-on: ${{ matrix.os.image }}


### PR DESCRIPTION
Start testing against Python 3.15, set to be released in October.