### PR TITLE
fix(requirements): honor byte order marks when reading requirements files

### DIFF
--- a/python/deptry/dependency_getter/requirements_files.py
+++ b/python/deptry/dependency_getter/requirements_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import codecs
 import itertools
 import logging
 import re
@@ -16,6 +17,16 @@ if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
     from requirements.requirement import Requirement
+
+
+# Byte order marks recognized by `pip`, ordered so that a longer mark is matched before a shorter prefix of it.
+BOM_ENCODINGS = (
+    (codecs.BOM_UTF8, "utf-8-sig"),
+    (codecs.BOM_UTF32_LE, "utf-32"),
+    (codecs.BOM_UTF32_BE, "utf-32"),
+    (codecs.BOM_UTF16_LE, "utf-16"),
+    (codecs.BOM_UTF16_BE, "utf-16"),
+)
 
 
 @dataclass
@@ -70,16 +81,29 @@ def get_dependencies_from_requirements_file(
     dependencies = []
     requirements_file = Path(file_name)
 
-    with requirements_file.open() as requirements_file_content:
-        for requirement in requirements.parse(requirements_file_content):
-            if (
-                dependency := _build_dependency_from_requirement(
-                    requirement, requirements_file, package_module_name_map
-                )
-            ) is not None:
-                dependencies.append(dependency)
+    for requirement in requirements.parse(_read_requirements_file(requirements_file)):
+        if (
+            dependency := _build_dependency_from_requirement(requirement, requirements_file, package_module_name_map)
+        ) is not None:
+            dependencies.append(dependency)
 
     return dependencies
+
+
+def _read_requirements_file(requirements_file: Path) -> str:
+    """
+    Read a requirements file, honoring the byte order mark if there is one.
+
+    `pip` supports requirements files encoded as UTF-8, UTF-16 or UTF-32 by looking at their BOM, so files that
+    `pip` can install from should also be parseable by deptry. Files without a BOM are decoded as UTF-8.
+    """
+    content = requirements_file.read_bytes()
+
+    for bom, encoding in BOM_ENCODINGS:
+        if content.startswith(bom):
+            return content.decode(encoding)
+
+    return content.decode("utf-8")
 
 
 def _build_dependency_from_requirement(

--- a/tests/unit/dependency_getter/test_requirements_txt.py
+++ b/tests/unit/dependency_getter/test_requirements_txt.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import codecs
 from pathlib import Path
+
+import pytest
 
 from deptry.dependency_getter.requirements_files import RequirementsTxtDependencyGetter
 from tests.utils import run_within_dir
@@ -178,3 +181,19 @@ def test_dev_multiple_with_arguments(tmp_path: Path) -> None:
 
         assert dev_dependencies[0].name == "click"
         assert dev_dependencies[1].name == "bar"
+
+
+@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16", "utf-16-le", "utf-16-be", "utf-32"])
+def test_parse_requirements_file_with_bom(tmp_path: Path, encoding: str) -> None:
+    """Requirements files that `pip` accepts thanks to their BOM should be parsed, not rejected."""
+    with run_within_dir(tmp_path):
+        content = "click==8.1.3\ncolorama==0.4.5\n"
+        if encoding in {"utf-16-le", "utf-16-be"}:
+            bom = codecs.BOM_UTF16_LE if encoding == "utf-16-le" else codecs.BOM_UTF16_BE
+            Path("requirements.txt").write_bytes(bom + content.encode(encoding))
+        else:
+            Path("requirements.txt").write_bytes(content.encode(encoding))
+
+        dependencies = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get().dependencies
+
+        assert [dependency.name for dependency in dependencies] == ["click", "colorama"]


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Closes #1393

`pip` decides the encoding of a requirements file from its byte order mark, so a UTF-16 encoded `requirements.txt` installs fine but made deptry fail — the file was opened with the default UTF-8 codec, so the BOM either raised `UnicodeDecodeError` or ended up inside the first package name (`Expected package name at the start of dependency specifier`). The file is now read as bytes and decoded according to its BOM, falling back to UTF-8 when there is none.

Added a parametrized regression test covering UTF-8/UTF-16/UTF-32 BOMs; it fails on `main` and passes with the fix.
