### PR TITLE
fix(poetry): honor non-dev dependency groups for Poetry dependency groups

### DIFF
--- a/docs/supported-dependency-managers.md
+++ b/docs/supported-dependency-managers.md
@@ -150,6 +150,12 @@ pytest = "8.3.3"
 pytest-cov = "5.0.0"
 ```
 
+!!! note
+
+    Groups under `[tool.poetry.group.<group>.dependencies]` can be flagged as regular dependency groups by
+    using [`--non-dev-dependency-groups`](configuration.md#non-dev-dependency-groups) argument (or its
+    `non_dev_dependency_groups` equivalent in `pyproject.toml`).
+
 ### PDM
 
 If a `[tool.pdm.dev-dependencies]` section is found, _deptry_ will assume that PDM is used as a dependency manager, and

--- a/python/deptry/dependency_getter/pep621/poetry.py
+++ b/python/deptry/dependency_getter/pep621/poetry.py
@@ -36,15 +36,32 @@ class PoetryDependencyGetter(PEP621DependencyGetter):
         pyproject_data = load_pyproject_toml(self.config)
         return self._extract_poetry_dependencies(pyproject_data["tool"]["poetry"].get("dependencies", {}))
 
+    def _get_dependency_groups_dependencies(self) -> dict[str, list[Dependency]]:
+        """
+        In addition to `[dependency-groups]` defined by PEP 735, Poetry has its own dependency groups, defined under
+        `[tool.poetry.group.<group>.dependencies]`. Both kinds are returned, so that groups listed in
+        `non_dev_dependency_groups` are extracted as regular dependencies whichever syntax declares them.
+        """
+        pyproject_data = load_pyproject_toml(self.config)
+
+        dependency_groups = super()._get_dependency_groups_dependencies()
+
+        for group, group_values in pyproject_data.get("tool", {}).get("poetry", {}).get("group", {}).items():
+            dependency_groups[group] = [
+                *dependency_groups.get(group, []),
+                *self._extract_poetry_dependencies(group_values.get("dependencies", {})),
+            ]
+
+        return dependency_groups
+
     def _get_dev_dependencies(
         self,
         dev_dependencies_from_optional: list[Dependency],
         dev_dependencies_from_dependency_groups: list[Dependency],
     ) -> list[Dependency]:
         """
-        Poetry's development dependencies can be specified under either, or both:
-        - [tool.poetry.dev-dependencies]
-        - [tool.poetry.group.<group>.dependencies]
+        In addition to the dependency groups handled by `_get_dependency_groups_dependencies`, Poetry supports legacy
+        development dependencies under `[tool.poetry.dev-dependencies]`.
         """
         dev_dependencies = super()._get_dev_dependencies(
             dev_dependencies_from_optional, dev_dependencies_from_dependency_groups
@@ -59,16 +76,7 @@ class PoetryDependencyGetter(PEP621DependencyGetter):
                 **pyproject_data["tool"]["poetry"]["dev-dependencies"],
             }
 
-        try:
-            dependency_groups = pyproject_data["tool"]["poetry"]["group"]
-        except KeyError:
-            dependency_groups = {}
-
-        for group_values in dependency_groups.values():
-            with contextlib.suppress(KeyError):
-                poetry_dev_dependencies = {**poetry_dev_dependencies, **group_values["dependencies"]}
-
-        return [*dev_dependencies, *self._extract_poetry_dependencies(poetry_dev_dependencies)]
+        return [*self._extract_poetry_dependencies(poetry_dev_dependencies), *dev_dependencies]
 
     def _extract_poetry_dependencies(self, poetry_dependencies: dict[str, Any]) -> list[Dependency]:
         return [

--- a/tests/unit/dependency_getter/test_poetry.py
+++ b/tests/unit/dependency_getter/test_poetry.py
@@ -164,3 +164,30 @@ name = "foo"
 
         assert len(dependencies_extract.dependencies) == 0
         assert len(dependencies_extract.dev_dependencies) == 0
+
+
+def test_dependency_getter_non_dev_dependency_groups(tmp_path: Path) -> None:
+    fake_pyproject_toml = """
+[tool.poetry]
+name = "foo"
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+bar = "^1.0.0"
+
+[tool.poetry.group.baremetal.dependencies]
+uvicorn = "^0.30.0"
+
+[tool.poetry.group.test.dependencies]
+pytest = "^7.3.0"
+"""
+
+    with run_within_dir(tmp_path):
+        with Path("pyproject.toml").open("w") as f:
+            f.write(fake_pyproject_toml)
+
+        getter = PoetryDependencyGetter(config=Path("pyproject.toml"), non_dev_dependency_groups=("baremetal",))
+        dependencies_extract = getter.get()
+
+        assert [dependency.name for dependency in dependencies_extract.dependencies] == ["bar", "uvicorn"]
+        assert [dependency.name for dependency in dependencies_extract.dev_dependencies] == ["pytest"]


### PR DESCRIPTION
Closes #1577

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

`non_dev_dependency_groups` only ever looked at PEP 735 `[dependency-groups]`, because `PoetryDependencyGetter` collected `[tool.poetry.group.<group>.dependencies]` straight into the dev dependency list instead of exposing them as dependency groups. Setting `non_dev_dependency_groups = ["baremetal"]` on a Poetry project therefore had no effect and warned that the group was not found.

Poetry groups are now returned from `_get_dependency_groups_dependencies()`, so the existing group splitting applies to them, and `_get_dev_dependencies()` only handles the legacy `[tool.poetry.dev-dependencies]` section. Extraction order is unchanged for projects that do not use the option (existing tests pass untouched).
