### PR TITLE
Security: Unsafe Unwrap in File Reading Error Handling

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -21,7 +21,7 @@ pub fn read_file(file_path: &str) -> PyResult<String> {
                 "File not found: '{file_path}'",
             ))),
             ErrorKind::InvalidData => {
-                let file = File::open(path).unwrap();
+                let file = File::open(path).map_err(|e| PyIOError::new_err(format!("An error occurred: '{e}'")))?;
                 let mut buffer = Vec::new();
                 BufReader::new(file).read_to_end(&mut buffer)?;
 


### PR DESCRIPTION
## Summary

Security: Unsafe Unwrap in File Reading Error Handling

## Problem

**Severity**: `Medium` | **File**: `src/file_utils.rs:L21`

In `src/file_utils.rs`, when `fs::read_to_string` fails with `InvalidData` (indicating an encoding issue), the code attempts to open the file again using `File::open(path).unwrap()`. If the file cannot be opened for a reason other than `InvalidData` (e.g., permissions changed, or a race condition where the file was deleted), this `unwrap()` will cause a panic, crashing the application.

## Solution

Replace `File::open(path).unwrap()` with proper error handling, such as returning a `PyIOError` if the file cannot be opened.

## Changes

- `src/file_utils.rs` (modified)