### PR TITLE
fix(cli): make comma-separated mapping error message generic and clearer

### DIFF
--- a/python/deptry/cli.py
+++ b/python/deptry/cli.py
@@ -80,7 +80,9 @@ class CommaSeparatedMappingParamType(click.ParamType[dict[str, tuple[str, ...]]]
                 pair = tuple(item.split("=", 1))
                 if len(pair) != 2:
                     error_msg = (
-                        f"package name and module names pairs should be concatenated with an equal sign (=): {item}"
+                        f"invalid mapping entry {item!r}: each entry must be a key and value joined by an "
+                        "equal sign (=), where multiple values are separated by a pipe (|), "
+                        "for example 'key1=value1,key2=value2|value3'"
                     )
                     raise ValueError(error_msg)
                 package_name = pair[0]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -185,6 +185,24 @@ def test_comma_separated_mapping_param_type_convert_err(
         param_type.convert(value=value, param=param, ctx=ctx)
 
 
+def test_comma_separated_mapping_param_type_convert_err_message_is_generic() -> None:
+    """The error should not assume the option is the package/module name map, since the type is shared."""
+    param = mock.Mock(spec=click.Parameter)
+    ctx = mock.Mock(spec=click.Context)
+    param_type = CommaSeparatedMappingParamType()
+
+    with pytest.raises(ValueError, match="equal sign") as exc_info:
+        param_type.convert(value="DEP001", param=param, ctx=ctx)
+
+    message = str(exc_info.value)
+    assert "package" not in message
+    assert "module" not in message
+    # The message should tell the user about both separators they might get wrong.
+    assert "equal sign" in message
+    assert "pipe" in message
+    assert "DEP001" in message
+
+
 def test_display_deptry_version(capsys: pytest.CaptureFixture[str]) -> None:
     ctx = mock.Mock(resilient_parsing=False, spec=click.Context)
     param = mock.Mock(spec=click.Parameter)


### PR DESCRIPTION
## Description of changes

Fixes #403.

`CommaSeparatedMappingParamType` is now used by both `--per-rule-ignores` and `--package-module-name-map`, but when an entry is malformed the error still only mentions package and module names:

```
$ deptry . --per-rule-ignores DEP001
ValueError: package name and module names pairs should be concatenated with an equal sign (=): DEP001
```

That is confusing for `--per-rule-ignores`, which has nothing to do with packages, and the message never mentions the pipe separator you use for multiple values. This reword drops the option-specific wording and spells out the expected format instead:

```
invalid mapping entry 'DEP001': each entry must be a key and value joined by an equal sign (=), where multiple values are separated by a pipe (|), for example 'key1=value1,key2=value2|value3'
```

Added a unit test that checks the message stays generic (no "package"/"module") and points at both the `=` and `|` separators.
